### PR TITLE
Always compare the entire key in HFSX binary comparisons

### DIFF
--- a/lib/libhfs/libhfs.c
+++ b/lib/libhfs/libhfs.c
@@ -2501,7 +2501,8 @@ hfslib_compare_catalog_keys_bc (
 		return memcmp(((const hfs_catalog_key_t*)a)->name.unicode,
 			((const hfs_catalog_key_t*)b)->name.unicode,
 			min(((const hfs_catalog_key_t*)a)->name.length,
-				((const hfs_catalog_key_t*)b)->name.length));
+				((const hfs_catalog_key_t*)b)->name.length)
+			* sizeof(unichar_t));
 	}
 	else
 	{


### PR DESCRIPTION
The memcmp in hfslib_compare_catalog_keys_bc only checks roughly half of the provided key. This led to lookups on "dir_205123" returning the entry for another catalog entry, "dir_205789", which shares a prefix.

This failure's reproduceability is of course contingent upon B-tree node ordering.

Signed-off-by: Dustin L. Howett <dustin@howett.net>