### PR TITLE
Add include/lib paths for OpenBSD in Makefile. Issue #18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ else ifeq ($(OS), DragonFly)
 	APP_FLAGS += -I/usr/local/include
 	APP_LIB += -L/usr/local/lib
 	FUSE_FLAGS += -I/usr/local/include
+else ifeq ($(OS), OpenBSD)
+	APP_FLAGS += -I/usr/local/include -I/usr/local/include/libutf8proc
+	APP_LIB += -L/usr/local/lib
 else ifeq ($(OS), NetBSD)
 $(info NetBSD detected, only hfsdump will be built by default)
 	TARGETS=hfsdump


### PR DESCRIPTION
This is a fix for include/library paths on OpenBSD 6.8 (see Issue #18).