### PR TITLE
Fix `allow_other`

### DIFF
--- a/src/hfsfuse.c
+++ b/src/hfsfuse.c
@@ -937,6 +937,9 @@ int main(int argc, char* argv[]) {
 
 	char* opts = NULL;
 	fuse_opt_add_opt(&opts, "ro");
+    // passthrough allow_other to fuse; otherwise our opt parser consumed it
+	if (cfg.allow_other_set)
+		fuse_opt_add_opt(&opts, "allow_other");
 #if FUSE_VERSION < 30
 	fuse_opt_add_opt(&opts, "use_ino");
 #endif


### PR DESCRIPTION
Fix `-o allow_other` not taking effect, as the `allow_other_set` check & option parser swallows the option before it reaches FUSE.

Before:
```
zonggao@zonggao-q6a:~/hfsfuse$ sudo ./hfsfuse /dev/sda2 ~/mnt -o uid=$(id -u),gid=$(id -g),umask=000,allow_other
zonggao@zonggao-q6a:~/hfsfuse$ ls ~/mnt
ls: cannot access '/home/zonggao/mnt': Permission denied
```

After:
```
zonggao@zonggao-q6a:~/hfsfuse$ sudo ./hfsfuse /dev/sda2 ~/mnt -o uid=$(id -u),gid=$(id -g),umask=000,allow_other
zonggao@zonggao-q6a:~/hfsfuse$ ls ~/mnt
Applications  Data  home  tmp1  torch  UTM
```